### PR TITLE
chore(adapter): bump version to 0.1.1 and fix dependency specs

### DIFF
--- a/packages/python/adapter/CHANGELOG.md
+++ b/packages/python/adapter/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-11-10
+
+### Fixed
+- Updated dependency specifications to comply with PEP 508 format
+
 ## [0.1.0] - 2024-10-30
 
 ### Added

--- a/packages/python/adapter/pyproject.toml
+++ b/packages/python/adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otlp-stdout-adapter"
-version = "0.1.0"
+version = "0.1.1"
 description = "A custom requests HTTPAdapter that serializes spans to stdout for OpenTelemetry OTLP exporters"
 readme = "README.md"
 authors = [{name = "Alessandro Bologna", email = "alessandro.bologna@gmail.com"}]
@@ -23,10 +23,10 @@ classifiers = [
 ]
 keywords = ["opentelemetry", "otlp", "stdout", "lambda", "aws"]
 dependencies = [
-    "opentelemetry-api~=1.27.0",
-    "opentelemetry-sdk~=1.27.0",
-    "opentelemetry-exporter-otlp-proto-http~=1.27.0",
-    "opentelemetry-semantic-conventions~=0.48b0",
+    "opentelemetry-api>=1.0.0,<2.0.0",
+    "opentelemetry-sdk>=1.0.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.0.0,<2.0.0",
+    "opentelemetry-semantic-conventions>=0.48b0",
     "requests>=2.31.0,<3.0.0",
 ]
 requires-python = ">=3.12"


### PR DESCRIPTION
# Update OTLP Adapter Dependencies and Version

## Changes
- Bump version from 0.1.0 to 0.1.1
- Update dependency specifications in `pyproject.toml` to support newer OpenTelemetry releases
- Update CHANGELOG.md to document changes

## Problem
The package had outdated dependency constraints that made it incompatible with newer releases of OpenTelemetry.

## Solution
Updated version constraints to support newer OpenTelemetry releases while maintaining compatibility.

## Testing
- [ ] Package installs successfully with `pip install -e .`
- [ ] Package installs successfully with `uv pip install -e .`