### PR TITLE
Fixing name clash in example

### DIFF
--- a/packages/node/exporter/README.md
+++ b/packages/node/exporter/README.md
@@ -89,7 +89,7 @@ async function processEvent(event) {
 }
 
 // Example Lambda handler with tracing
-exports.handler = async (event, context) => {
+exports.handler = async (event, lambdaContext) => {
   const parentSpan = tracer.startSpan('lambda_handler', {
     kind: SpanKind.SERVER
   });


### PR DESCRIPTION
The `context` parameter in the handler hides the `context` from `@opentelemetry/api`