### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ rust-version = "1.70"
 otlp-stdout-client = { path = "packages/rust/otlp-stdout-client", version = "0.2.2" }
 otlp-sigv4-client = { path = "packages/rust/otlp-sigv4-client", version = "0.1.0" }
 lambda-otel-utils = { path = "packages/rust/lambda-otel-utils", version = "0.2.2" }
-lambda-lw-http-router = { path = "packages/rust/lambda-lw-http-router" }
-lambda-lw-http-router-core = { path = "packages/rust/lambda-lw-http-router/router-core" }
-lambda-lw-http-router-macro = { path = "packages/rust/lambda-lw-http-router/router-macro" }
+lambda-lw-http-router = { path = "packages/rust/lambda-lw-http-router", version = "0.1.2" }
+lambda-lw-http-router-core = { path = "packages/rust/lambda-lw-http-router/router-core", version = "0.1.2" }
+lambda-lw-http-router-macro = { path = "packages/rust/lambda-lw-http-router/router-macro", version = "0.1.1" }
 
 # Runtime and async
 tokio = { version = "1", features = ["full"] }

--- a/packages/rust/lambda-lw-http-router/CHANGELOG.md
+++ b/packages/rust/lambda-lw-http-router/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-12-13
+
+### Fixed
+- Fixed https://github.com/dev7a/lambda-otlp-forwarder/issues/22
+- Updated dependency for lambda-lw-http-router-core dependency to version 0.1.2
+
 ## [0.1.1] - 2024-11-23
 
 ### Changed

--- a/packages/rust/lambda-lw-http-router/Cargo.toml
+++ b/packages/rust/lambda-lw-http-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-lw-http-router"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/lambda-lw-http-router/router-core/CHANGELOG.md
+++ b/packages/rust/lambda-lw-http-router/router-core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-12-13
+
+### Fixed
+- Fixed https://github.com/dev7a/lambda-otlp-forwarder/issues/22
+
 ## [0.1.1] - 2024-11-23
 
 ### Added

--- a/packages/rust/lambda-lw-http-router/router-core/Cargo.toml
+++ b/packages/rust/lambda-lw-http-router/router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-lw-http-router-core"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/lambda-lw-http-router/router-core/src/routable_http_event.rs
+++ b/packages/rust/lambda-lw-http-router/router-core/src/routable_http_event.rs
@@ -110,8 +110,8 @@ pub trait RoutableHttpEvent: Send + Sync + Clone + 'static {
         span.record("otel.kind", "SERVER");
 
         // HTTP request attributes
-        span.record("http.request.method", self.http_method());
-        span.record("http.route", route_pattern.to_string());
+        span.set_attribute("http.request.method", self.http_method());
+        span.set_attribute("http.route", route_pattern.to_string());
 
         // URL attributes
         span.set_attribute("url.path", self.path().unwrap_or_else(|| "/".to_string()));


### PR DESCRIPTION
This pull request focuses on updating the versioning of several packages and fixing an issue related to the `lambda-otlp-forwarder`. The changes include updates to version numbers in `Cargo.toml` files and modifications to the `CHANGELOG.md` files to reflect these updates. Additionally, there is a minor change in the `RoutableHttpEvent` trait implementation.

Version updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L29-R31): Updated version numbers for `lambda-lw-http-router`, `lambda-lw-http-router-core`, and `lambda-lw-http-router-macro` to `0.1.2`, `0.1.2`, and `0.1.1` respectively.
* [`packages/rust/lambda-lw-http-router/Cargo.toml`](diffhunk://#diff-3722c5b2dbe44fd3af7d3bf11046624ae1438a949774c8a5c8768ee995a8c6b6L3-R3): Updated version to `0.1.2`.
* [`packages/rust/lambda-lw-http-router/router-core/Cargo.toml`](diffhunk://#diff-80a2b45d2336978417b8c0517b3f02b55c6d9569b37b0d0db275739664a30bb9L3-R3): Updated version to `0.1.2`.

Changelog updates:

* [`packages/rust/lambda-lw-http-router/CHANGELOG.md`](diffhunk://#diff-e8e3e808a04ac199c8a315ff08d5afeb291c6c7100ebccdd4d1b3f9a6486c41dR7-R12): Added entry for version `0.1.2` with details of the fixed issue and updated dependency.
* [`packages/rust/lambda-lw-http-router/router-core/CHANGELOG.md`](diffhunk://#diff-a27b0ddff67479190981394571f59eb59e95eb6d62b3a350faefda63be1d89ecR7-R11): Added entry for version `0.1.2` with details of the fixed issue.

Code improvements:

* [`packages/rust/lambda-lw-http-router/router-core/src/routable_http_event.rs`](diffhunk://#diff-92501208845b25f3f26a869907b735f979c424549f2f1c562c25a1d642c2bba2L113-R114): Replaced `span.record` with `span.set_attribute` for setting HTTP request attributes.